### PR TITLE
Support LZMA on Python 2 via backports.lzma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: python
 
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - liblzma-dev
+
 python:
   - 2.7
   - 3.4

--- a/numcodecs/__init__.py
+++ b/numcodecs/__init__.py
@@ -25,7 +25,6 @@ import atexit
 
 from numcodecs.version import version as __version__
 from numcodecs.registry import get_codec, register_codec
-from numcodecs.compat import PY2
 
 from numcodecs.zlib import Zlib
 register_codec(Zlib)
@@ -33,9 +32,11 @@ register_codec(Zlib)
 from numcodecs.bz2 import BZ2
 register_codec(BZ2)
 
-if not PY2:
+try:
     from numcodecs.lzma import LZMA
     register_codec(LZMA)
+except ImportError:  # pragma: no cover
+    pass
 
 try:
     from numcodecs import blosc as _blosc

--- a/numcodecs/lzma.py
+++ b/numcodecs/lzma.py
@@ -2,11 +2,17 @@
 from __future__ import absolute_import, print_function, division
 
 
+_lzma = None
 try:
     import lzma as _lzma
 except ImportError:  # pragma: no cover
-    pass
-else:
+    try:
+        from backports import lzma as _lzma
+    except ImportError:
+        pass
+
+
+if _lzma:
 
     import numpy as np
     from numcodecs.abc import Codec

--- a/numcodecs/tests/test_lzma.py
+++ b/numcodecs/tests/test_lzma.py
@@ -2,12 +2,18 @@
 from __future__ import absolute_import, print_function, division
 
 
-from numcodecs.compat import PY2
-
-
-if not PY2:
-
+_lzma = None
+try:
     import lzma as _lzma
+except ImportError:  # pragma: no cover
+    try:
+        from backports import lzma as _lzma
+    except ImportError:
+        pass
+
+
+if _lzma:
+
     import itertools
     import numpy as np
     from numcodecs.lzma import LZMA

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist = py27, py34, py35, docs
 setenv =
     PYTHONHASHSEED = 42
 commands =
+    py27: pip install -U backports.lzma
     python setup.py build_ext --inplace
     py27: nosetests -v numcodecs
     py34,py35: nosetests -v --with-coverage --cover-erase --cover-min-percentage=100 --cover-package=numcodecs --with-doctest --doctest-options=+NORMALIZE_WHITESPACE numcodecs


### PR DESCRIPTION
Fixes https://github.com/alimanfoo/numcodecs/issues/11

Tries to use `backports.lzma` as a fallback. Adds testing for it with Travis CI.