### PR TITLE
Review msgpack pickle

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,13 +28,13 @@ class Mock(MagicMock):
         return Mock()
 
 
-MOCK_MODULES = []
+MOCK_MODULES = ['msgpack']
 if PY2:
     MOCK_MODULES.append('lzma')
 
 
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
-                        
+
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,6 +59,8 @@ Contents
     packbits
     categorize
     checksum32
+    pickles
+    msgpacks
     release
 
 Acknowledgments

--- a/docs/msgpacks.rst
+++ b/docs/msgpacks.rst
@@ -1,0 +1,7 @@
+MsgPack
+=======
+.. automodule:: numcodecs.msgpacks
+
+.. autoclass:: MsgPack
+
+    .. autoattribute:: codec_id

--- a/docs/pickles.rst
+++ b/docs/pickles.rst
@@ -1,0 +1,7 @@
+Pickle
+======
+.. automodule:: numcodecs.pickles
+
+.. autoclass:: Pickle
+
+    .. autoattribute:: codec_id

--- a/numcodecs/msgpacks.py
+++ b/numcodecs/msgpacks.py
@@ -6,13 +6,11 @@ import numpy as np
 
 
 from numcodecs.abc import Codec
-from numcodecs.compat import ndarray_from_buffer, buffer_copy
 import msgpack
 
 
 class MsgPack(Codec):
-    """Codec to encode data as msgpacked bytes. Useful for encoding python
-    strings
+    """Codec to encode data as msgpacked bytes. Useful for encoding an array of Python strings
 
     Raises
     ------
@@ -27,14 +25,16 @@ class MsgPack(Codec):
     >>> f.decode(f.encode(x))
     array(['foo', 'bar', 'baz'], dtype=object)
 
+    See Also
+    --------
+    :class:`numcodecs.pickles.Pickle`
+
     """  # flake8: noqa
 
     codec_id = 'msgpack'
 
     def encode(self, buf):
-        if hasattr(buf, 'dtype') and buf.dtype != 'object':
-            raise ValueError("cannot encode non-object ndarrays, %s "
-                             "dtype was passed" % buf.dtype)
+        buf = np.asarray(buf, dtype='object')
         return msgpack.packb(buf.tolist(), encoding='utf-8')
 
     def decode(self, buf, out=None):

--- a/numcodecs/msgpacks.py
+++ b/numcodecs/msgpacks.py
@@ -10,11 +10,7 @@ import msgpack
 
 
 class MsgPack(Codec):
-    """Codec to encode data as msgpacked bytes. Useful for encoding an array of Python strings
-
-    Raises
-    ------
-    encoding a non-object dtyped ndarray will raise ValueError
+    """Codec to encode data as msgpacked bytes. Useful for encoding an array of Python strings.
 
     Examples
     --------
@@ -28,6 +24,10 @@ class MsgPack(Codec):
     See Also
     --------
     :class:`numcodecs.pickles.Pickle`
+
+    Notes
+    -----
+    Requires `msgpack-python <https://pypi.python.org/pypi/msgpack-python>`_ to be installed.
 
     """  # flake8: noqa
 

--- a/numcodecs/msgpacks.py
+++ b/numcodecs/msgpacks.py
@@ -10,7 +10,8 @@ import msgpack
 
 
 class MsgPack(Codec):
-    """Codec to encode data as msgpacked bytes. Useful for encoding an array of Python strings.
+    """Codec to encode data as msgpacked bytes. Useful for encoding an array of Python string
+    objects.
 
     Examples
     --------
@@ -33,12 +34,18 @@ class MsgPack(Codec):
 
     codec_id = 'msgpack'
 
+    def __init__(self, encoding='utf-8'):
+        self.encoding = encoding
+
     def encode(self, buf):
-        buf = np.asarray(buf, dtype='object')
-        return msgpack.packb(buf.tolist(), encoding='utf-8')
+        buf = np.asarray(buf)
+        l = buf.tolist()
+        l.append(buf.dtype.str)
+        return msgpack.packb(l, encoding=self.encoding)
 
     def decode(self, buf, out=None):
-        dec = np.array(msgpack.unpackb(buf, encoding='utf-8'), dtype='object')
+        l = msgpack.unpackb(buf, encoding=self.encoding)
+        dec = np.array(l[:-1], dtype=l[-1])
         if out is not None:
             np.copyto(out, dec)
             return out
@@ -46,7 +53,8 @@ class MsgPack(Codec):
             return dec
 
     def get_config(self):
-        return dict(id=self.codec_id)
+        return dict(id=self.codec_id,
+                    encoding=self.encoding)
 
     def __repr__(self):
-        return 'MsgPack()'
+        return 'MsgPack(encoding=%r)' % self.encoding

--- a/numcodecs/pickles.py
+++ b/numcodecs/pickles.py
@@ -21,10 +21,6 @@ class Pickle(Codec):
     protocol : int, defaults to pickle.HIGHEST_PROTOCOL
         The protocol used to pickle data.
 
-    Raises
-    ------
-    Encoding a non-object dtyped ndarray will raise ValueError.
-
     Examples
     --------
     >>> import numcodecs as codecs

--- a/numcodecs/pickles.py
+++ b/numcodecs/pickles.py
@@ -14,7 +14,8 @@ except ImportError:
 
 
 class Pickle(Codec):
-    """Codec to encode data as as pickled bytes. Useful for encoding an array of Python strings.
+    """Codec to encode data as as pickled bytes. Useful for encoding an array of Python string
+    objects.
 
     Parameters
     ----------
@@ -42,7 +43,6 @@ class Pickle(Codec):
         self.protocol = protocol
 
     def encode(self, buf):
-        buf = np.asarray(buf, dtype='object')
         return pickle.dumps(buf, protocol=self.protocol)
 
     def decode(self, buf, out=None):

--- a/numcodecs/pickles.py
+++ b/numcodecs/pickles.py
@@ -14,17 +14,16 @@ except ImportError:
 
 
 class Pickle(Codec):
-    """Codec to encode data as as pickled bytes. Useful for encoding python
-    strings.
+    """Codec to encode data as as pickled bytes. Useful for encoding an array of Python strings.
 
     Parameters
     ----------
     protocol : int, defaults to pickle.HIGHEST_PROTOCOL
-        the protocol used to pickle data
+        The protocol used to pickle data.
 
     Raises
     ------
-    encoding a non-object dtyped ndarray will raise ValueError
+    Encoding a non-object dtyped ndarray will raise ValueError.
 
     Examples
     --------
@@ -35,6 +34,10 @@ class Pickle(Codec):
     >>> f.decode(f.encode(x))
     array(['foo', 'bar', 'baz'], dtype=object)
 
+    See Also
+    --------
+    :class:`numcodecs.msgpacks.MsgPack`
+
     """  # flake8: noqa
 
     codec_id = 'pickle'
@@ -43,9 +46,7 @@ class Pickle(Codec):
         self.protocol = protocol
 
     def encode(self, buf):
-        if hasattr(buf, 'dtype') and buf.dtype != 'object':
-            raise ValueError("cannot encode non-object ndarrays, %s "
-                             "dtype was passed" % buf.dtype)
+        buf = np.asarray(buf, dtype='object')
         return pickle.dumps(buf, protocol=self.protocol)
 
     def decode(self, buf, out=None):

--- a/numcodecs/tests/common.py
+++ b/numcodecs/tests/common.py
@@ -117,7 +117,7 @@ def check_encode_decode_objects(arr, codec):
     dec = codec.decode(enc)
     compare(dec)
 
-    out = np.empty_like(arr)
+    out = np.empty_like(arr, dtype='object')
     codec.decode(enc, out=out)
     compare(out)
 

--- a/numcodecs/tests/common.py
+++ b/numcodecs/tests/common.py
@@ -91,16 +91,13 @@ def check_encode_decode(arr, codec, precision=None):
     compare(out)
 
 
-def check_encode_decode_objects(arr, codec):
-
-    # this is a more specific test that check_encode_decode
-    # as these require actual objects (and not bytes only)
+def check_encode_decode_array(arr, codec):
 
     def compare(res, arr=arr):
 
         assert_true(isinstance(res, np.ndarray))
         assert_true(res.shape == arr.shape)
-        assert_true(res.dtype == 'object')
+        assert_true(res.dtype == arr.dtype)
 
         # numpy asserts don't compare object arrays
         # properly; assert that we have the same nans
@@ -117,7 +114,7 @@ def check_encode_decode_objects(arr, codec):
     dec = codec.decode(enc)
     compare(dec)
 
-    out = np.empty_like(arr, dtype='object')
+    out = np.empty_like(arr)
     codec.decode(enc, out=out)
     compare(out)
 

--- a/numcodecs/tests/test_lzma.py
+++ b/numcodecs/tests/test_lzma.py
@@ -1,54 +1,49 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
+import itertools
 
 
-_lzma = None
+import nose
+import numpy as np
+
 try:
-    import lzma as _lzma
-except ImportError:  # pragma: no cover
-    try:
-        from backports import lzma as _lzma
-    except ImportError:
-        pass
+    from numcodecs.lzma import LZMA, _lzma
+except ImportError:
+    raise nose.SkipTest("LZMA not available")
+
+from numcodecs.tests.common import check_encode_decode, check_config, check_repr
 
 
-if _lzma:
+codecs = [
+    LZMA(),
+    LZMA(preset=1),
+    LZMA(preset=5),
+    LZMA(preset=9),
+    LZMA(format=_lzma.FORMAT_RAW, filters=[dict(id=_lzma.FILTER_LZMA2, preset=1)])
+]
 
-    import itertools
-    import numpy as np
-    from numcodecs.lzma import LZMA
-    from numcodecs.tests.common import check_encode_decode, check_config, \
-        check_repr
 
-    codecs = [
-        LZMA(),
-        LZMA(preset=1),
-        LZMA(preset=5),
-        LZMA(preset=9),
-        LZMA(format=_lzma.FORMAT_RAW,
-             filters=[dict(id=_lzma.FILTER_LZMA2, preset=1)])
-    ]
+# mix of dtypes: integer, float, bool, string
+# mix of shapes: 1D, 2D, 3D
+# mix of orders: C, F
+arrays = [
+    np.arange(1000, dtype='i4'),
+    np.linspace(1000, 1001, 1000, dtype='f8'),
+    np.random.normal(loc=1000, scale=1, size=(100, 10)),
+    np.random.randint(0, 2, size=1000, dtype=bool).reshape(100, 10, order='F'),
+    np.random.choice([b'a', b'bb', b'ccc'], size=1000).reshape(10, 10, 10)
+]
 
-    # mix of dtypes: integer, float, bool, string
-    # mix of shapes: 1D, 2D, 3D
-    # mix of orders: C, F
-    arrays = [
-        np.arange(1000, dtype='i4'),
-        np.linspace(1000, 1001, 1000, dtype='f8'),
-        np.random.normal(loc=1000, scale=1, size=(100, 10)),
-        np.random.randint(0, 2, size=1000, dtype=bool).reshape(100, 10,
-                                                               order='F'),
-        np.random.choice([b'a', b'bb', b'ccc'], size=1000).reshape(10, 10, 10)
-    ]
 
-    def test_encode_decode():
-        for arr, codec in itertools.product(arrays, codecs):
-            check_encode_decode(arr, codec)
+def test_encode_decode():
+    for arr, codec in itertools.product(arrays, codecs):
+        check_encode_decode(arr, codec)
 
-    def test_config():
-        codec = LZMA(preset=1, format=_lzma.FORMAT_XZ,
-                     check=_lzma.CHECK_NONE, filters=None)
-        check_config(codec)
 
-    def test_repr():
-        check_repr('LZMA(format=1, check=0, preset=1, filters=None)')
+def test_config():
+    codec = LZMA(preset=1, format=_lzma.FORMAT_XZ, check=_lzma.CHECK_NONE, filters=None)
+    check_config(codec)
+
+
+def test_repr():
+    check_repr('LZMA(format=1, check=0, preset=1, filters=None)')

--- a/numcodecs/tests/test_lzma.py
+++ b/numcodecs/tests/test_lzma.py
@@ -8,7 +8,7 @@ import numpy as np
 
 try:
     from numcodecs.lzma import LZMA, _lzma
-except ImportError:
+except ImportError:  # pragma: no cover
     raise nose.SkipTest("LZMA not available")
 
 from numcodecs.tests.common import check_encode_decode, check_config, check_repr

--- a/numcodecs/tests/test_msgpacks.py
+++ b/numcodecs/tests/test_msgpacks.py
@@ -3,10 +3,15 @@ from __future__ import absolute_import, print_function, division
 
 
 import numpy as np
+import nose
 from numpy.testing import assert_raises
-from numcodecs.msgpacks import MsgPack
-from numcodecs.tests.common import (check_config, check_repr,
-                                    check_encode_decode_objects)
+
+try:
+    from numcodecs.msgpacks import MsgPack
+except ImportError:
+    raise nose.SkipTest("msgpack-python not available")
+
+from numcodecs.tests.common import check_config, check_repr, check_encode_decode_objects
 
 
 # object array with strings
@@ -17,6 +22,7 @@ arrays = [
     np.array([['foo', 'bar', np.nan]] * 300, dtype=object),
     np.array(['foo', 1.0, 2] * 300, dtype=object),
 ]
+
 
 # non-object ndarrays
 arrays_incompat = [

--- a/numcodecs/tests/test_msgpacks.py
+++ b/numcodecs/tests/test_msgpacks.py
@@ -10,7 +10,7 @@ try:
 except ImportError:  # pragma: no cover
     raise nose.SkipTest("msgpack-python not available")
 
-from numcodecs.tests.common import check_config, check_repr, check_encode_decode_objects
+from numcodecs.tests.common import check_config, check_repr, check_encode_decode_array
 
 
 # object array with strings
@@ -28,7 +28,7 @@ arrays = [
 def test_encode_decode():
     for arr in arrays:
         codec = MsgPack()
-        check_encode_decode_objects(arr, codec)
+        check_encode_decode_array(arr, codec)
 
 
 def test_config():
@@ -37,4 +37,5 @@ def test_config():
 
 
 def test_repr():
-    check_repr("MsgPack()")
+    check_repr("MsgPack(encoding='utf-8')")
+    check_repr("MsgPack(encoding='ascii')")

--- a/numcodecs/tests/test_msgpacks.py
+++ b/numcodecs/tests/test_msgpacks.py
@@ -7,7 +7,7 @@ import nose
 
 try:
     from numcodecs.msgpacks import MsgPack
-except ImportError:
+except ImportError:  # pragma: no cover
     raise nose.SkipTest("msgpack-python not available")
 
 from numcodecs.tests.common import check_config, check_repr, check_encode_decode_objects

--- a/numcodecs/tests/test_msgpacks.py
+++ b/numcodecs/tests/test_msgpacks.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, print_function, division
 
 import numpy as np
 import nose
-from numpy.testing import assert_raises
 
 try:
     from numcodecs.msgpacks import MsgPack
@@ -21,20 +20,9 @@ arrays = [
     np.array(['foo', 'bar', 'baz'] * 300, dtype=object),
     np.array([['foo', 'bar', np.nan]] * 300, dtype=object),
     np.array(['foo', 1.0, 2] * 300, dtype=object),
-]
-
-
-# non-object ndarrays
-arrays_incompat = [
     np.arange(1000, dtype='i4'),
     np.array(['foo', 'bar', 'baz'] * 300),
 ]
-
-
-def test_encode_errors():
-    for arr in arrays_incompat:
-        codec = MsgPack()
-        assert_raises(ValueError, codec.encode, arr)
 
 
 def test_encode_decode():

--- a/numcodecs/tests/test_pickles.py
+++ b/numcodecs/tests/test_pickles.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 from numcodecs.pickles import Pickle
-from numcodecs.tests.common import check_config, check_repr, check_encode_decode_objects
+from numcodecs.tests.common import check_config, check_repr, check_encode_decode_array
 
 
 # object array with strings
@@ -24,7 +24,7 @@ arrays = [
 def test_encode_decode():
     codec = Pickle()
     for arr in arrays:
-        check_encode_decode_objects(arr, codec)
+        check_encode_decode_array(arr, codec)
 
 
 def test_config():

--- a/numcodecs/tests/test_pickles.py
+++ b/numcodecs/tests/test_pickles.py
@@ -3,12 +3,10 @@ from __future__ import absolute_import, print_function, division
 
 
 import numpy as np
-from numpy.testing import assert_raises
 
 
 from numcodecs.pickles import Pickle
-from numcodecs.tests.common import (check_config, check_repr,
-                                    check_encode_decode_objects)
+from numcodecs.tests.common import check_config, check_repr, check_encode_decode_objects
 
 
 # object array with strings
@@ -18,24 +16,14 @@ arrays = [
     np.array(['foo', 'bar', 'baz'] * 300, dtype=object),
     np.array([['foo', 'bar', np.nan]] * 300, dtype=object),
     np.array(['foo', 1.0, 2] * 300, dtype=object),
-]
-
-# non-object ndarrays
-arrays_incompat = [
     np.arange(1000, dtype='i4'),
     np.array(['foo', 'bar', 'baz'] * 300),
 ]
 
 
-def test_encode_errors():
-    for arr in arrays_incompat:
-        codec = Pickle()
-        assert_raises(ValueError, codec.encode, arr)
-
-
 def test_encode_decode():
+    codec = Pickle()
     for arr in arrays:
-        codec = Pickle()
         check_encode_decode_objects(arr, codec)
 
 

--- a/setup.py
+++ b/setup.py
@@ -172,6 +172,9 @@ def run_setup(with_extensions):
         install_requires=[
             'numpy>=1.7',
         ],
+        extras_require={
+            'msgpack':  ["msgpack-python"],
+        },
         ext_modules=ext_modules,
         cmdclass=cmdclass,
         package_dir={'': '.'},

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ envlist = py27, py34, py35, py36, docs
 setenv =
     PYTHONHASHSEED = 42
 commands =
-    py27: pip install -U backports.lzma
     python setup.py build_ext --inplace
     py27,py34,py35: nosetests -v numcodecs --with-coverage --cover-erase --cover-package=numcodecs
     py36: nosetests -v --with-coverage --cover-erase --cover-package=numcodecs --with-doctest --doctest-options=+NORMALIZE_WHITESPACE numcodecs
@@ -18,6 +17,7 @@ commands =
     python setup.py bdist_wheel
     coverage report -m
 deps =
+    py27: backports.lzma
     -rrequirements_dev.txt
 
 [testenv:docs]


### PR DESCRIPTION
This PR includes three changesets:

* Add API docs for pickle and msgpack codecs (resolves #6).
* Add msgpack-python as optional dependency (resolves #8).
* Review behaviour of pickle and msgpack codecs under various inputs.

I decided to relax slightly the constraints on inputs to encoding, these shouldn't make a difference for the main motivating use case (encoding of object arrays) and so I've opted for minimal constraints, maximum generality. Both codecs will now encode arrays with any dtype, preserving the dtype when decoding.