### PR TITLE
Add setup.py hooks to disable AVX2, SSE2 or C extensions altogether

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,14 @@ Intel Haswell, Broadwell or Skylake) then installing via pip is preferable,
 because this will compile the Blosc library from source with optimisations
 for AVX2.
 
+Note that if you compile the C extensions on a machine with AVX2 support
+you probably then cannot use the same binaries on a machine without AVX2.
+To disable compilation with AVX2 support regardless of the machine
+architecture:
+
+    $ export DISABLE_NUMCODECS_AVX2=
+    $ pip install numcodecs
+
 To work with Numcodecs source code in development, install from GitHub::
 
     $ git clone --recursive https://github.com/alimanfoo/numcodecs.git

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -53,6 +53,13 @@ Other new features:
   help with understanding the shuffle option
   (`#4 <https://github.com/alimanfoo/numcodecs/issues/4>`_,
   `#19 <https://github.com/alimanfoo/numcodecs/issues/19>`_).
+* Options have been added to manually control how the C extensions are built regardless of the
+  architecture of the system on which the build is run. To disable support for AVX2 set the
+  environment variable "DISABLE_NUMCODECS_AVX2". To disable support for SSE2 set the environment
+  variable "DISABLE_NUMCODECS_SSE2". To disable C extensions altogether set the environment variable
+  "DISABLE_NUMCODECS_CEXT"
+  (`#24 <https://github.com/alimanfoo/numcodecs/issues/24>`_,
+  `#26 <https://github.com/alimanfoo/numcodecs/issues/26>`_).
 
 Maintenance work:
 

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,8 @@ def blosc_extension():
     cpu_info = cpuinfo.get_cpu_info()
 
     # SSE2
-    if 'sse2' in cpu_info['flags']:
-        info('SSE2 detected')
+    if 'sse2' in cpu_info['flags'] and 'DISABLE_NUMCODECS_SSE2' not in os.environ:
+        info('building with SSE2 support')
         extra_compile_args.append('-DSHUFFLE_SSE2_ENABLED')
         blosc_sources += [f for f in glob('c-blosc/blosc/*.c') if 'sse2' in f]
         if os.name == 'posix':
@@ -75,8 +75,8 @@ def blosc_extension():
             define_macros += [('__SSE2__', 1)]
 
     # AVX2
-    if 'avx2' in cpu_info['flags']:
-        info('AVX2 detected')
+    if 'avx2' in cpu_info['flags'] and 'DISABLE_NUMCODECS_AVX2' not in os.environ:
+        info('building with AVX2 support')
         extra_compile_args.append('-DSHUFFLE_AVX2_ENABLED')
         blosc_sources += [f for f in glob('c-blosc/blosc/*.c') if 'avx2' in f]
         if os.name == 'posix':
@@ -308,12 +308,13 @@ def run_setup(with_extensions):
 
 if __name__ == '__main__':
     is_pypy = hasattr(sys, 'pypy_translation_info')
+    with_extensions = not is_pypy and 'DISABLE_NUMCODECS_CEXT' not in os.environ
 
     try:
-        run_setup(not is_pypy)
+        run_setup(with_extensions)
     except BuildFailed:
         error('*' * 75)
-        error('compilation of the Blosc C extension failed.')
+        error('compilation of C extensions failed.')
         error('retrying installation without C extensions...')
         error('*' * 75)
         run_setup(False)


### PR DESCRIPTION
Resolves #24.