### PR TITLE
Make gzip an alias for zlib

### DIFF
--- a/numcodecs/__init__.py
+++ b/numcodecs/__init__.py
@@ -28,6 +28,7 @@ from numcodecs.registry import get_codec, register_codec
 
 from numcodecs.zlib import Zlib
 register_codec(Zlib)
+register_codec(Zlib, 'gzip')  # alias
 
 from numcodecs.bz2 import BZ2
 register_codec(BZ2)

--- a/numcodecs/astype.py
+++ b/numcodecs/astype.py
@@ -7,7 +7,6 @@ from numcodecs.abc import Codec
 from numcodecs.compat import buffer_copy, ndarray_from_buffer
 
 
-
 class AsType(Codec):
     """Filter to convert data between different types.
 

--- a/numcodecs/pickles.py
+++ b/numcodecs/pickles.py
@@ -6,7 +6,6 @@ import numpy as np
 
 
 from numcodecs.abc import Codec
-from numcodecs.compat import ndarray_from_buffer, buffer_copy
 try:
     import cPickle as pickle
 except ImportError:

--- a/numcodecs/registry.py
+++ b/numcodecs/registry.py
@@ -36,7 +36,7 @@ def get_codec(config):
     return cls.from_config(config)
 
 
-def register_codec(cls):
+def register_codec(cls, codec_id=None):
     """Register a codec class.
 
     Parameters
@@ -50,4 +50,6 @@ def register_codec(cls):
     previously registered under the same codec identifier, if present.
 
     """
-    codec_registry[cls.codec_id] = cls
+    if codec_id is None:
+        codec_id = cls.codec_id
+    codec_registry[codec_id] = cls

--- a/numcodecs/tests/test_zlib.py
+++ b/numcodecs/tests/test_zlib.py
@@ -4,9 +4,10 @@ import itertools
 
 
 import numpy as np
-
+from nose.tools import eq_ as eq
 
 from numcodecs.zlib import Zlib
+from numcodecs.registry import get_codec
 from numcodecs.tests.common import check_encode_decode, check_config, \
     check_repr
 
@@ -45,3 +46,9 @@ def test_config():
 
 def test_repr():
     check_repr("Zlib(level=3)")
+
+
+def test_alias():
+    config = dict(id='gzip', level=1)
+    codec = get_codec(config)
+    eq(Zlib(1), codec)


### PR DESCRIPTION
Adds 'gzip' as an alias for 'zlib' codec, for compatibility with h5py, to resolve #29.